### PR TITLE
pr Feat/#9 루틴 관련 api 구현

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineLogResponse.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineLogResponse.java
@@ -9,9 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoutineResponse {
-    private Long id;
-    private String name;
-
-
+public class RoutineLogResponse {
+    private String nickName;
+    private String routineName;
+    private Boolean isCompleted;
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineResponse.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineResponse.java
@@ -1,0 +1,14 @@
+package FortuneMonBackEnd.fortuneMon.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutineResponse {
+    private String name;
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineResponse.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineResponse.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RoutineResponse {
+    private Long id;
     private String name;
-
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineStatisticsResponse.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/RoutineStatisticsResponse.java
@@ -1,0 +1,29 @@
+package FortuneMonBackEnd.fortuneMon.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoutineStatisticsResponse {
+    private String nickName;
+    private List<statisticsResponse> statistics;
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class statisticsResponse {
+        private String routineName;
+        private Map<LocalDate, Boolean> daysStatistics;
+    }
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserResponseDTO.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserResponseDTO.java
@@ -42,5 +42,6 @@ public class UserResponseDTO {
     public static class UsersRoutineDTO {
         private String nickName;
 
+
     }
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserResponseDTO.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserResponseDTO.java
@@ -35,5 +35,12 @@ public class UserResponseDTO {
         private String nickname;
     }
 
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    @Getter
+    @Builder
+    public static class UsersRoutineDTO {
+        private String nickName;
 
+    }
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserResponseDTO.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserResponseDTO.java
@@ -41,7 +41,8 @@ public class UserResponseDTO {
     @Builder
     public static class UsersRoutineDTO {
         private String nickName;
-
+        private String routineName;
+        private String message;
 
     }
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserRoutineInfoResponseDTO.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserRoutineInfoResponseDTO.java
@@ -5,11 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoutineResponse {
-    private String name;
-
+public class UserRoutineInfoResponseDTO {
+        private String name;
+        private Boolean isCompleted;
+        private LocalDateTime createdAt;
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserRoutineResponse.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/DTO/UserRoutineResponse.java
@@ -1,15 +1,19 @@
 package FortuneMonBackEnd.fortuneMon.DTO;
 
+import FortuneMonBackEnd.fortuneMon.domain.UserRoutine;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RoutineResponse {
-    private String name;
-
+public class UserRoutineResponse {
+    private String nickname;
+    private List<UserRoutineInfoResponseDTO> routines;
 }
+

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/apiPayload/code/status/ErrorStatus.java
@@ -30,7 +30,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 토큰 관련 응답 2000
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN_2001", "클라이언트의 토큰이 없거나, 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN_2002", "Refresh 토큰이 서버에 없거나, 사용자의 Refresh 토큰이 유효하지 않습니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN_2003", "Access 토큰이 유효하지 않습니다.");
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN_2003", "Access 토큰이 유효하지 않습니다."),
+
+    // 루틴 관련 응답 3000
+    ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE_3001", "해당 루틴이 존재하지 않습니다."),
+    ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE_3002", "해당 루틴은 이미 진행중입니다 !");
 
 
 

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/apiPayload/code/status/ErrorStatus.java
@@ -34,7 +34,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 루틴 관련 응답 3000
     ROUTINE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE_3001", "해당 루틴이 존재하지 않습니다."),
-    ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE_3002", "해당 루틴은 이미 진행중입니다 !");
+    ROUTINE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ROUTINE_3002", "해당 루틴은 이미 진행중입니다 !"),
+    ROUTINE_LOG_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROUTINE_3003", "해당 루틴 로그가 존재하지 않습니다.");
 
 
 

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/config/security/SecurityUtil.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/config/security/SecurityUtil.java
@@ -1,0 +1,18 @@
+package FortuneMonBackEnd.fortuneMon.config.security;
+
+import FortuneMonBackEnd.fortuneMon.domain.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class SecurityUtil {
+    public static Long getCurrentUserId() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof User user) {
+            return user.getId();
+        }
+
+        throw new IllegalStateException("로그인 정보가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/RoutineController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/RoutineController.java
@@ -1,0 +1,36 @@
+package FortuneMonBackEnd.fortuneMon.controller;
+
+import FortuneMonBackEnd.fortuneMon.DTO.RoutineResponse;
+import FortuneMonBackEnd.fortuneMon.apiPayload.ApiResponse;
+import FortuneMonBackEnd.fortuneMon.service.RoutineService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/routines")
+@RequiredArgsConstructor
+public class RoutineController {
+
+    private final RoutineService routineService;
+
+
+    @Operation(summary = "카테고리 별 루틴 조회", description =
+            "# 카테고리 별 루틴 조회 API 입니다. 카테고리 이름을 입력해주세요."
+    )
+    @GetMapping("")
+    public ApiResponse<?> getRoutines(@RequestParam String category) {
+
+        List<RoutineResponse> response = routineService.getRoutines(category);
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
@@ -2,16 +2,14 @@ package FortuneMonBackEnd.fortuneMon.controller;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
 import FortuneMonBackEnd.fortuneMon.apiPayload.ApiResponse;
 import FortuneMonBackEnd.fortuneMon.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -50,5 +48,13 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
+    @Operation(summary = "유저의 진행중인 루틴 조회", description =
+            "# 유저의 진행중인 루틴 조회 API 입니다. 로그인 후 진행하세요. "
+    )
+    @GetMapping("/routine")
+    public ApiResponse<?> getMyRoutines() {
+        UserRoutineResponse response = userService.getMyRoutines();
+        return ApiResponse.onSuccess(response);
+    }
 
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
@@ -57,4 +57,13 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
+    @Operation(summary = "유저의 진행중인 루틴 추가", description =
+            "# 유저의 진행중인 루틴 추가 API 입니다. 로그인 후 진행하세요. "
+    )
+    @PostMapping("/routines/{id}")
+    public ApiResponse<?> setMyRoutines(@PathVariable("id") Long routineId) {
+        UserRoutineResponse response = userService.setMyRoutines(routineId);
+        return ApiResponse.onSuccess(response);
+    }
+
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
@@ -1,9 +1,6 @@
 package FortuneMonBackEnd.fortuneMon.controller;
 
-import FortuneMonBackEnd.fortuneMon.DTO.RoutineLogResponse;
-import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
+import FortuneMonBackEnd.fortuneMon.DTO.*;
 import FortuneMonBackEnd.fortuneMon.apiPayload.ApiResponse;
 import FortuneMonBackEnd.fortuneMon.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +8,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -82,6 +81,15 @@ public class UserController {
     @PatchMapping("/routines/{id}/status")
     public ApiResponse<?> setMyRoutineStatus(@PathVariable("id") Long routineId) {
         RoutineLogResponse response = userService.setMyRoutineStatus(routineId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "유저의 루틴 수행 관련 통계 조회", description =
+            "# 유저의 루틴 수행 관련 통계 조회 API 입니다. 로그인 후 진행하세요. "
+    )
+    @GetMapping("/routines/{date}/statistics")
+    public ApiResponse<?> getMyRoutineStatistics(@PathVariable LocalDate date) {
+        RoutineStatisticsResponse response = userService.getMyRoutinesStatistics(date);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
@@ -1,5 +1,6 @@
 package FortuneMonBackEnd.fortuneMon.controller;
 
+import FortuneMonBackEnd.fortuneMon.DTO.RoutineLogResponse;
 import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
@@ -75,10 +76,14 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
-//    @PatchMapping("/routines/{id}/status")
-//    public ApiResponse<?> setMyRoutineStatus(@PathVariable("id") Long routineId) {
-//
-//    }
+    @Operation(summary = "유저의 진행중인 루틴 수행여부 수정", description =
+            "# 유저의 진행중인 루틴 삭제 API 입니다. 로그인 후 진행하세요. "
+    )
+    @PatchMapping("/routines/{id}/status")
+    public ApiResponse<?> setMyRoutineStatus(@PathVariable("id") Long routineId) {
+        RoutineLogResponse response = userService.setMyRoutineStatus(routineId);
+        return ApiResponse.onSuccess(response);
+    }
 
 
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserController.java
@@ -62,8 +62,23 @@ public class UserController {
     )
     @PostMapping("/routines/{id}")
     public ApiResponse<?> setMyRoutines(@PathVariable("id") Long routineId) {
-        UserRoutineResponse response = userService.setMyRoutines(routineId);
+        UserResponseDTO.UsersRoutineDTO response = userService.setMyRoutines(routineId);
         return ApiResponse.onSuccess(response);
     }
+
+    @Operation(summary = "유저의 진행중인 루틴 삭제", description =
+            "# 유저의 진행중인 루틴 삭제 API 입니다. 로그인 후 진행하세요. "
+    )
+    @DeleteMapping("/routines/{id}")
+    public ApiResponse<?> deleteMyRoutines(@PathVariable("id") Long routineId) {
+        UserResponseDTO.UsersRoutineDTO response = userService.deleteMyRoutines(routineId);
+        return ApiResponse.onSuccess(response);
+    }
+
+//    @PatchMapping("/routines/{id}/status")
+//    public ApiResponse<?> setMyRoutineStatus(@PathVariable("id") Long routineId) {
+//
+//    }
+
 
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/domain/RoutineLog.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/domain/RoutineLog.java
@@ -2,8 +2,7 @@ package FortuneMonBackEnd.fortuneMon.domain;
 
 import FortuneMonBackEnd.fortuneMon.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,6 +12,9 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RoutineLog extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/domain/UserRoutine.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/domain/UserRoutine.java
@@ -29,7 +29,7 @@ public class UserRoutine extends BaseEntity {
     @JoinColumn(name = "routine_id")
     private Routine routine;
 
-    @OneToMany(mappedBy = "userRoutine")
+    @OneToMany(mappedBy = "userRoutine", cascade = CascadeType.ALL)
     private List<RoutineLog> routineLog;
 
 

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/domain/UserRoutine.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/domain/UserRoutine.java
@@ -16,12 +16,6 @@ public class UserRoutine extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
-    private String category;
-
-    @Column(nullable = false, length = 20)
-    private String name;
-
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/domain/UserRoutine.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/domain/UserRoutine.java
@@ -2,8 +2,7 @@ package FortuneMonBackEnd.fortuneMon.domain;
 
 import FortuneMonBackEnd.fortuneMon.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -11,6 +10,12 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "routine_id"})
+})
 public class UserRoutine extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineLogRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineLogRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RoutineLogRepository extends JpaRepository<RoutineLog, Long> {
     Optional<RoutineLog> findByUserRoutineIdAndDate(Long id, LocalDate date);
+
+    List<RoutineLog> findByUserRoutineIdInAndDateBetween(List<Long> userRoutineIds, LocalDate startOfMonth, LocalDate endOfMonth);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineLogRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineLogRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 @Repository
 public interface RoutineLogRepository extends JpaRepository<RoutineLog, Long> {
+    Optional<RoutineLog> findByUserRoutineIdAndDate(Long id, LocalDate date);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineLogRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineLogRepository.java
@@ -1,0 +1,10 @@
+package FortuneMonBackEnd.fortuneMon.repository;
+
+import FortuneMonBackEnd.fortuneMon.domain.RoutineLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoutineLogRepository extends JpaRepository<RoutineLog, Long> {
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     List<Routine> findAllByCategory(String category);
+
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineRepository.java
@@ -1,0 +1,11 @@
+package FortuneMonBackEnd.fortuneMon.repository;
+
+import FortuneMonBackEnd.fortuneMon.domain.Routine;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+
+    List<Routine> findAllByCategory(String category);
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/RoutineRepository.java
@@ -2,9 +2,11 @@ package FortuneMonBackEnd.fortuneMon.repository;
 
 import FortuneMonBackEnd.fortuneMon.domain.Routine;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     List<Routine> findAllByCategory(String category);

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
@@ -8,10 +8,12 @@ import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Repository
 public interface UserRoutineRepository extends JpaRepository<UserRoutine, Long> {
 
     @Query("SELECT new FortuneMonBackEnd.fortuneMon.DTO.UserRoutineInfoResponseDTO( " +

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
@@ -28,4 +28,6 @@ public interface UserRoutineRepository extends JpaRepository<UserRoutine, Long> 
     List<UserRoutineInfoResponseDTO> findUserRoutinesWithLog(@Param("userId") Long userId, @Param("today") LocalDate today);
 
     Optional<UserRoutine> findByUserIdAndRoutineId(Long userId, Long routineId);
+
+    List<UserRoutine> findAllByUserId(Long userId);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRoutineRepository extends JpaRepository<UserRoutine, Long> {
@@ -25,4 +26,6 @@ public interface UserRoutineRepository extends JpaRepository<UserRoutine, Long> 
             "LEFT JOIN RoutineLog rl ON rl.userRoutine = ur AND rl.date = :today " +
             "WHERE ur.user.id = :userId")
     List<UserRoutineInfoResponseDTO> findUserRoutinesWithLog(@Param("userId") Long userId, @Param("today") LocalDate today);
+
+    Optional<UserRoutine> findByUserIdAndRoutineId(Long userId, Long routineId);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/UserRoutineRepository.java
@@ -1,0 +1,26 @@
+package FortuneMonBackEnd.fortuneMon.repository;
+
+import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineInfoResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
+import FortuneMonBackEnd.fortuneMon.domain.RoutineLog;
+import FortuneMonBackEnd.fortuneMon.domain.UserRoutine;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface UserRoutineRepository extends JpaRepository<UserRoutine, Long> {
+
+    @Query("SELECT new FortuneMonBackEnd.fortuneMon.DTO.UserRoutineInfoResponseDTO( " +
+            "r.name, " +
+            "COALESCE(rl.isCompleted, false), " +
+            "ur.createdAt) " +
+            "FROM UserRoutine ur " +
+            "JOIN ur.routine r " +
+            "LEFT JOIN RoutineLog rl ON rl.userRoutine = ur AND rl.date = :today " +
+            "WHERE ur.user.id = :userId")
+    List<UserRoutineInfoResponseDTO> findUserRoutinesWithLog(@Param("userId") Long userId, @Param("today") LocalDate today);
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/RoutineService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/RoutineService.java
@@ -1,0 +1,9 @@
+package FortuneMonBackEnd.fortuneMon.service;
+
+import FortuneMonBackEnd.fortuneMon.DTO.RoutineResponse;
+
+import java.util.List;
+
+public interface RoutineService {
+    List<RoutineResponse> getRoutines(String category);
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/RoutineServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/RoutineServiceImpl.java
@@ -21,6 +21,7 @@ public class RoutineServiceImpl implements RoutineService {
 
         List<RoutineResponse> responses = routines.stream()
                 .map(routine -> new RoutineResponse(
+                        routine.getId(),
                         routine.getName()
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/RoutineServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/RoutineServiceImpl.java
@@ -1,0 +1,30 @@
+package FortuneMonBackEnd.fortuneMon.service;
+
+import FortuneMonBackEnd.fortuneMon.DTO.RoutineResponse;
+import FortuneMonBackEnd.fortuneMon.domain.Routine;
+import FortuneMonBackEnd.fortuneMon.repository.RoutineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineServiceImpl implements RoutineService {
+
+    private final RoutineRepository routineRepository;
+
+    @Override
+    public List<RoutineResponse> getRoutines(String category) {
+        List<Routine> routines = routineRepository.findAllByCategory(category);
+
+        List<RoutineResponse> responses = routines.stream()
+                .map(routine -> new RoutineResponse(
+                        routine.getName()
+                ))
+                .collect(Collectors.toList());
+
+        return responses;
+    }
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
@@ -14,5 +14,7 @@ public interface UserService {
 
     UserRoutineResponse getMyRoutines();
 
-    UserRoutineResponse setMyRoutines(Long routineId);
+    UserResponseDTO.UsersRoutineDTO setMyRoutines(Long routineId);
+
+    UserResponseDTO.UsersRoutineDTO deleteMyRoutines(Long routineId);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
@@ -1,10 +1,9 @@
 package FortuneMonBackEnd.fortuneMon.service;
 
-import FortuneMonBackEnd.fortuneMon.DTO.RoutineLogResponse;
-import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
+import FortuneMonBackEnd.fortuneMon.DTO.*;
 import jakarta.validation.Valid;
+
+import java.time.LocalDate;
 
 public interface UserService {
     UserResponseDTO.SignUpResponseDTO signUp(UserRequestDTO.@Valid SignUpRequestDTO request);
@@ -20,4 +19,6 @@ public interface UserService {
     UserResponseDTO.UsersRoutineDTO deleteMyRoutines(Long routineId);
 
     RoutineLogResponse setMyRoutineStatus(Long routineId);
+
+    RoutineStatisticsResponse getMyRoutinesStatistics(LocalDate date);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
@@ -13,4 +13,6 @@ public interface UserService {
     UserResponseDTO.RefreshTokenResponseDTO refresh(String authHeader, String refreshToken);
 
     UserRoutineResponse getMyRoutines();
+
+    UserRoutineResponse setMyRoutines(Long routineId);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
@@ -2,6 +2,7 @@ package FortuneMonBackEnd.fortuneMon.service;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
 import jakarta.validation.Valid;
 
 public interface UserService {
@@ -10,4 +11,6 @@ public interface UserService {
     UserResponseDTO.SignInResponseDTO signIn(UserRequestDTO.@Valid SignInRequestDTO request);
 
     UserResponseDTO.RefreshTokenResponseDTO refresh(String authHeader, String refreshToken);
+
+    UserRoutineResponse getMyRoutines();
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserService.java
@@ -1,5 +1,6 @@
 package FortuneMonBackEnd.fortuneMon.service;
 
+import FortuneMonBackEnd.fortuneMon.DTO.RoutineLogResponse;
 import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
@@ -17,4 +18,6 @@ public interface UserService {
     UserResponseDTO.UsersRoutineDTO setMyRoutines(Long routineId);
 
     UserResponseDTO.UsersRoutineDTO deleteMyRoutines(Long routineId);
+
+    RoutineLogResponse setMyRoutineStatus(Long routineId);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserServiceImpl.java
@@ -2,11 +2,15 @@ package FortuneMonBackEnd.fortuneMon.service;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
 import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineInfoResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
 import FortuneMonBackEnd.fortuneMon.apiPayload.code.status.ErrorStatus;
 import FortuneMonBackEnd.fortuneMon.apiPayload.exception.GeneralException;
+import FortuneMonBackEnd.fortuneMon.config.security.SecurityUtil;
 import FortuneMonBackEnd.fortuneMon.domain.User;
 import FortuneMonBackEnd.fortuneMon.jwt.JwtUtil;
 import FortuneMonBackEnd.fortuneMon.repository.UserRepository;
+import FortuneMonBackEnd.fortuneMon.repository.UserRoutineRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -14,6 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +30,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
+    private final UserRoutineRepository userRoutineRepository;
 
     @Override
     public UserResponseDTO.SignUpResponseDTO signUp(UserRequestDTO.SignUpRequestDTO request) {
@@ -99,5 +107,20 @@ public class UserServiceImpl implements UserService {
                 .nickname(user.getNickname())
                 .build();
 
+    }
+
+    @Override
+    public UserRoutineResponse getMyRoutines() {
+        Long userId = SecurityUtil.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<UserRoutineInfoResponseDTO> routines =
+                userRoutineRepository.findUserRoutinesWithLog(userId, LocalDate.now());
+
+        return UserRoutineResponse.builder()
+                .nickname(user.getNickname())
+                .routines(routines)
+                .build();
     }
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserServiceImpl.java
@@ -1,9 +1,6 @@
 package FortuneMonBackEnd.fortuneMon.service;
 
-import FortuneMonBackEnd.fortuneMon.DTO.UserRequestDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserResponseDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineInfoResponseDTO;
-import FortuneMonBackEnd.fortuneMon.DTO.UserRoutineResponse;
+import FortuneMonBackEnd.fortuneMon.DTO.*;
 import FortuneMonBackEnd.fortuneMon.apiPayload.code.status.ErrorStatus;
 import FortuneMonBackEnd.fortuneMon.apiPayload.exception.GeneralException;
 import FortuneMonBackEnd.fortuneMon.config.security.SecurityUtil;
@@ -184,6 +181,31 @@ public class UserServiceImpl implements UserService {
                 .routineName(routine.getName())
                 .message(routine.getName() + " 삭제 완료")
                 .build();
+    }
 
+    @Override
+    public RoutineLogResponse setMyRoutineStatus(Long routineId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        UserRoutine userRoutine = userRoutineRepository.findByUserIdAndRoutineId(userId, routineId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        RoutineLog routineLog = routineLogRepository.findByUserRoutineIdAndDate(userRoutine.getId(), LocalDate.now())
+                .orElseThrow(()-> new GeneralException(ErrorStatus.ROUTINE_LOG_NOT_FOUND));
+
+        routineLog.setIsCompleted(!routineLog.getIsCompleted());
+        routineLogRepository.save(routineLog);
+
+        return RoutineLogResponse.builder()
+                .nickName(user.getNickname())
+                .routineName(routine.getName())
+                .isCompleted(routineLog.getIsCompleted())
+                .build();
     }
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserServiceImpl.java
@@ -130,7 +130,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserRoutineResponse setMyRoutines(Long routineId) {
+    public UserResponseDTO.UsersRoutineDTO setMyRoutines(Long routineId) {
         Long userId = SecurityUtil.getCurrentUserId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
@@ -158,12 +158,32 @@ public class UserServiceImpl implements UserService {
 
         routineLogRepository.save(routineLog);
 
-        List<UserRoutineInfoResponseDTO> routines =
-                userRoutineRepository.findUserRoutinesWithLog(userId, LocalDate.now());
-
-        return UserRoutineResponse.builder()
-                .nickname(user.getNickname())
-                .routines(routines)
+        return UserResponseDTO.UsersRoutineDTO.builder()
+                .nickName(user.getNickname())
+                .routineName(routine.getName())
+                .message(routine.getName() + " 추가 완료")
                 .build();
+    }
+
+    @Override
+    public UserResponseDTO.UsersRoutineDTO deleteMyRoutines(Long routineId) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Routine routine = routineRepository.findById(routineId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        UserRoutine userRoutine = userRoutineRepository.findByUserIdAndRoutineId(userId, routineId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ROUTINE_NOT_FOUND));
+
+        userRoutineRepository.delete(userRoutine);
+
+        return UserResponseDTO.UsersRoutineDTO.builder()
+                .nickName(user.getNickname())
+                .routineName(routine.getName())
+                .message(routine.getName() + " 삭제 완료")
+                .build();
+
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #9 

## 📝작업 내용
>
[카테고리 별 루틴 조회 api 완료]
[securityutil.userId 추출 메소드 구현, 유저의 진행중인 루틴 조회 API 구현]
[user_routine table unique 제약조건 추가, 유저의 진행중인 루틴 추가]
[루틴 추가, 삭제 응답 변경, 삭제 구현 완료]
[유저의 진행중인 루틴 수행여부 수정]
[유저의 루틴 수행 관련 통계 조회 api 구현완료]

## 🔎코드 설명
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.