### PR TITLE
feat: #15 몬스터볼 뽑기 및 도감 저장 기능 구현

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserMonsterBallController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserMonsterBallController.java
@@ -1,12 +1,12 @@
 package FortuneMonBackEnd.fortuneMon.controller;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserMonsterBallResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserPokemonDTO;
 import FortuneMonBackEnd.fortuneMon.config.security.SecurityUtil;
 import FortuneMonBackEnd.fortuneMon.service.UserMonsterBallService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.repository.query.Param;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -21,5 +21,10 @@ public class UserMonsterBallController {
         Long userId = SecurityUtil.getCurrentUserId();
 
         return userMonsterBallService.getUserMonsterBall(userId);
+    }
+
+    @PostMapping("/{id}/open")
+    public UserPokemonDTO openMonsterBall(@PathVariable("id") Long ballId){
+        return userMonsterBallService.openMonsterBall(ballId);
     }
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/repository/PokemonBallRateRepository.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/repository/PokemonBallRateRepository.java
@@ -1,0 +1,12 @@
+package FortuneMonBackEnd.fortuneMon.repository;
+
+import FortuneMonBackEnd.fortuneMon.domain.PokemonBallRate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PokemonBallRateRepository extends JpaRepository<PokemonBallRate, Long> {
+    List<PokemonBallRate> findAllByBallId(Long ballId);
+}

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserMonsterBallService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserMonsterBallService.java
@@ -1,9 +1,14 @@
 package FortuneMonBackEnd.fortuneMon.service;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserMonsterBallResponseDTO;
+import FortuneMonBackEnd.fortuneMon.DTO.UserPokemonDTO;
 
 import java.util.List;
 
 public interface UserMonsterBallService {
+    //유저의 몬스터볼을 조회
     List<UserMonsterBallResponseDTO> getUserMonsterBall(Long userId);
+
+    //몬스터볼을 뽑고 포켓몬을 도감에 저장
+    UserPokemonDTO openMonsterBall(Long ballId);
 }


### PR DESCRIPTION
몬스터볼에서 확률에 따라 포켓몬을 뽑고 도감에 저장한 후 뽑은 포켓몬을 반환한다다

## #️⃣연관된 이슈
> #15

## 📝작업 내용
> 몬스터볼 뽑기 및 도감 저장 기능 구현

## 🔎코드 설명
> 클라이언트가 ballId를 전달하면 해당 볼의 확률에 따라 포켓몬을 뽑고 userPokemon 테이블에 저장한다

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.