### PR TITLE
feat: #17 파트너 포켓몬 설정 구현

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserPokemonController.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/controller/UserPokemonController.java
@@ -2,26 +2,29 @@ package FortuneMonBackEnd.fortuneMon.controller;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserPokemonDTO;
 import FortuneMonBackEnd.fortuneMon.config.security.SecurityUtil;
-import FortuneMonBackEnd.fortuneMon.service.UserPokemonService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import FortuneMonBackEnd.fortuneMon.service.UserPokemonServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
 public class UserPokemonController {
-    private final UserPokemonService userPokemonService;
-
-    public UserPokemonController(UserPokemonService userPokemonService){
-        this.userPokemonService=userPokemonService;
-    }
+    private final UserPokemonServiceImpl userPokemonService;
 
     // 요청 받으면 Service 호출해서 유저가 보유한 포켓몬을 표시하여 반환함
     // 유저의 id를 받아서 id를 기준으로 유저의 포켓몬 정보를 가져온다
-    @GetMapping("/users/pokemons")
+    @GetMapping("/pokemons")
     public List<UserPokemonDTO> getPokemonsWithOwnership(){
         Long userId = SecurityUtil.getCurrentUserId();
         return userPokemonService.getUserPokemonsWithOwnership(userId);
+    }
+
+    @PatchMapping("/partners/{id}")
+    public UserPokemonDTO setPartnerPokemon(@PathVariable("id") Long pokemonId){
+        return userPokemonService.setPartnerPokemon(pokemonId);
     }
 
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserPokemonService.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserPokemonService.java
@@ -1,46 +1,11 @@
 package FortuneMonBackEnd.fortuneMon.service;
 
 import FortuneMonBackEnd.fortuneMon.DTO.UserPokemonDTO;
-import FortuneMonBackEnd.fortuneMon.domain.Pokemon;
-import FortuneMonBackEnd.fortuneMon.domain.UserPokemon;
-import FortuneMonBackEnd.fortuneMon.repository.PokemonRepository;
-import FortuneMonBackEnd.fortuneMon.repository.UserPokemonRepository;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-@Service
-public class UserPokemonService {
+public interface UserPokemonService {
+    List<UserPokemonDTO> getUserPokemonsWithOwnership(Long userId);
 
-    private final PokemonRepository pokemonRepository;
-    private final UserPokemonRepository userPokemonRepository;
-
-    public UserPokemonService(PokemonRepository pokemonRepository, UserPokemonRepository userPokemonRepository){
-        this.pokemonRepository=pokemonRepository;
-        this.userPokemonRepository=userPokemonRepository;
-    }
-
-    public List<UserPokemonDTO> getUserPokemonsWithOwnership(Long userId){
-        // DB에 존재하는 모든 포켓몬 가져오기
-        List<Pokemon> allPokemons = pokemonRepository.findAll();
-
-        // 유저가 가진 포켓몬 가져오기
-        List<UserPokemon> userPokemons = userPokemonRepository.findByUserId(userId);
-
-        // 유저가 가진 포켓몬의 Id(전체 포켓몬이 저장된 테이블에서의 Id) 가져오기
-        Set<Long> userOwnedPokemon = userPokemons.stream().map(pokemon -> pokemon.getPokemon().getId())
-                .collect(Collectors.toSet());
-
-        // 전체 포켓몬 Id를 참조하면서 유저가 가진 포켓몬 Id Set에 있는지를 확인하고 boolean 타입으로 저장하고 return
-        return allPokemons.stream().map(pokemon -> new UserPokemonDTO(
-                pokemon.getId(),
-                pokemon.getName(),
-                pokemon.getUrl(),
-                pokemon.getType(),
-                pokemon.getGroupName(),
-                userOwnedPokemon.contains(pokemon.getId())
-        )).collect(Collectors.toList());
-    }
+    UserPokemonDTO setPartnerPokemon(Long pokemonId);
 }

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserPokemonServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserPokemonServiceImpl.java
@@ -1,0 +1,67 @@
+package FortuneMonBackEnd.fortuneMon.service;
+
+import FortuneMonBackEnd.fortuneMon.DTO.UserPokemonDTO;
+import FortuneMonBackEnd.fortuneMon.config.security.SecurityUtil;
+import FortuneMonBackEnd.fortuneMon.domain.Pokemon;
+import FortuneMonBackEnd.fortuneMon.domain.UserPokemon;
+import FortuneMonBackEnd.fortuneMon.repository.PokemonRepository;
+import FortuneMonBackEnd.fortuneMon.repository.UserPokemonRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserPokemonServiceImpl implements UserPokemonService {
+
+    private final PokemonRepository pokemonRepository;
+    private final UserPokemonRepository userPokemonRepository;
+
+
+    public List<UserPokemonDTO> getUserPokemonsWithOwnership(Long userId){
+        // DB에 존재하는 모든 포켓몬 가져오기
+        List<Pokemon> allPokemons = pokemonRepository.findAll();
+
+        // 유저가 가진 포켓몬 가져오기
+        List<UserPokemon> userPokemons = userPokemonRepository.findByUserId(userId);
+
+        // 유저가 가진 포켓몬의 Id(전체 포켓몬이 저장된 테이블에서의 Id) 가져오기
+        Set<Long> userOwnedPokemon = userPokemons.stream().map(pokemon -> pokemon.getPokemon().getId())
+                .collect(Collectors.toSet());
+
+        // 전체 포켓몬 Id를 참조하면서 유저가 가진 포켓몬 Id Set에 있는지를 확인하고 boolean 타입으로 저장하고 return
+        return allPokemons.stream().map(pokemon -> new UserPokemonDTO(
+                pokemon.getId(),
+                pokemon.getName(),
+                pokemon.getUrl(),
+                pokemon.getType(),
+                pokemon.getGroupName(),
+                userOwnedPokemon.contains(pokemon.getId())
+        )).collect(Collectors.toList());
+    }
+
+    //파트너 설정
+    public UserPokemonDTO setPartnerPokemon(Long pokemonId){
+        Long userId = SecurityUtil.getCurrentUserId();
+        List<UserPokemon> userPokemons = userPokemonRepository.findByUserId(userId);
+        UserPokemonDTO userPokemonDTO = null;
+        for(UserPokemon userPokemon : userPokemons){
+            if(userPokemon.getId().equals(pokemonId)){
+                userPokemon.setIsPartner(true);
+                userPokemonDTO = new UserPokemonDTO(userPokemon.getId(), userPokemon.getPokemon().getName(),
+                        userPokemon.getPokemon().getUrl(), userPokemon.getPokemon().getType(),
+                        userPokemon.getPokemon().getGroupName(), true);
+                userPokemonRepository.save(userPokemon);
+            }
+            else if(userPokemon.getIsPartner()){
+                userPokemon.setIsPartner(false);
+                userPokemonRepository.save(userPokemon);
+            }
+        }
+        return userPokemonDTO;
+    }
+}


### PR DESCRIPTION
전달받은 아이디의 포켓몬을 파트너로 설정하고 기존의 파트너는 해제한다다

## #️⃣연관된 이슈
> #17

## 📝작업 내용
> 파트너 설정 구현

## 🔎코드 설명
> 파트너로 설정할 포켓몬의 id를 전달하면 해당 포켓몬을 파트너로 설정하고 이전의 포켓몬은 파트너 해제한다

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.