### PR TITLE
fix: #27 중복 포켓몬 획득 경우 처리

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserMonsterBallServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserMonsterBallServiceImpl.java
@@ -52,10 +52,20 @@ public class UserMonsterBallServiceImpl implements UserMonsterBallService{
             return null;
         }
         Pokemon pokemon = pokemonRepository.findById(pokemonRate.getPokemonId()).orElse(null);
+
         Long userId = SecurityUtil.getCurrentUserId();
         User user = userRepository.findById(userId).orElse(null);
-        UserPokemon userPokemon = new UserPokemon();
 
+        // 이미 보유하고 있는 포켓몬인 경우 db에 추가하지 않고 바로 정보 리턴
+        List<UserPokemon> userPokemons = userPokemonRepository.findByUserId(userId);
+        for(UserPokemon existPokemon : userPokemons){
+            if(existPokemon.getPokemon().getId().equals(pokemon.getId())){
+                return new UserPokemonDTO(pokemon.getId(), pokemon.getName(), pokemon.getUrl(), pokemon.getType(),
+                        pokemon.getGroupName(), true);
+            }
+        }
+
+        UserPokemon userPokemon = new UserPokemon();
         userPokemon.setUser(user);
         userPokemon.setPokemon(pokemon);
         userPokemon.setIsPartner(false);


### PR DESCRIPTION
중복 포켓몬을 획득하면 db에 추가되지 않도록 수정

## #️⃣연관된 이슈
> #27 

## 📝작업 내용
> 중복 포켓몬을 획득하면 db에 추가하지 않고 바로 뽑은 포켓몬 정보 반환

## 🔎코드 설명
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.