### PR TITLE
fix: #51 운세 뽑기 수정

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/domain/Fortune.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/domain/Fortune.java
@@ -15,8 +15,8 @@ public class Fortune extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
-    @JoinColumn(name = "ball_id", unique = true)
+    @ManyToOne
+    @JoinColumn(name = "ball_id")
     private MonsterBall monsterBall;
 
     @Column(nullable = false, length = 20)

--- a/src/main/java/FortuneMonBackEnd/fortuneMon/domain/MonsterBall.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/domain/MonsterBall.java
@@ -25,7 +25,7 @@ public class MonsterBall extends BaseEntity {
     @OneToMany(mappedBy = "monsterBall")
     private List<UserBall> userBall;
 
-    @OneToOne(mappedBy = "monsterBall")
-    private Fortune fortune;
+    @OneToMany(mappedBy = "monsterBall")
+    private List<Fortune> fortune;
 }
 


### PR DESCRIPTION
진행중인 루틴의 카테고리별로 운세를 뽑도록 수정, 루틴이 없으면 모든 카테고리 제공, 운세와 몬스터볼 관계 수정

## #️⃣연관된 이슈
> #51 

## 📝작업 내용
> 운세 뽑기 시 제공되는 카테고리 수정 및 운세와 몬스터볼 관계 수정

## 🔎코드 설명
> 운세를 뽑으면 진행중인 루틴의 카테고리별로 운세 제공, 루틴 없으면 전부 제공, 운세와 몬스터볼을 다대1로 관계 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.