### PR TITLE
fix: #55 포켓몬 뽑기 시 볼 오픈 true로 변경

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserMonsterBallServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserMonsterBallServiceImpl.java
@@ -47,7 +47,8 @@ public class UserMonsterBallServiceImpl implements UserMonsterBallService{
         double rand = Math.random();
         double cumulative = 0.0;
         PokemonBallRate pokemonRate = null;
-        List<PokemonBallRate> rates = pokemonBallRateRepository.findAllByBallId(ballId);
+        UserBall openBall = userMonsterBallRepository.findById(ballId).orElse(null);
+        List<PokemonBallRate> rates = pokemonBallRateRepository.findAllByBallId(openBall.getMonsterBall().getId());
 
         for(PokemonBallRate rate : rates){
             cumulative += rate.getProbability();
@@ -60,6 +61,7 @@ public class UserMonsterBallServiceImpl implements UserMonsterBallService{
             return null;
         }
         Pokemon pokemon = pokemonRepository.findById(pokemonRate.getPokemonId()).orElse(null);
+        openBall.setOpen(true); // 볼 사용 표시
 
         Long userId = SecurityUtil.getCurrentUserId();
         User user = userRepository.findById(userId).orElse(null);


### PR DESCRIPTION
포켓몬을 뽑으면 사용한 볼을 오픈했음을 표시하도록 변경

## #️⃣연관된 이슈
> #55

## 📝작업 내용
> 포켓몬 뽑으면 볼 오픈으로 변경

## 🔎코드 설명
> 볼을 사용하면 오픈했음을 표시하도록 변경

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.