### PR TITLE
fixL #70 파트너 포켓몬 설정 수정

### DIFF
--- a/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserPokemonServiceImpl.java
+++ b/src/main/java/FortuneMonBackEnd/fortuneMon/service/UserPokemonServiceImpl.java
@@ -54,9 +54,9 @@ public class UserPokemonServiceImpl implements UserPokemonService {
         List<UserPokemon> userPokemons = userPokemonRepository.findByUserId(userId);
         UserPokemonDTO userPokemonDTO = null;
         for(UserPokemon userPokemon : userPokemons){
-            if(userPokemon.getId().equals(pokemonId)){
+            if(userPokemon.getPokemon().getId().equals(pokemonId)){
                 userPokemon.setIsPartner(true);
-                userPokemonDTO = new UserPokemonDTO(userPokemon.getId(), userPokemon.getPokemon().getName(),
+                userPokemonDTO = new UserPokemonDTO(userPokemon.getPokemon().getId(), userPokemon.getPokemon().getName(),
                         userPokemon.getPokemon().getUrl(), Arrays.stream(userPokemon.getPokemon().getType().split(","))
                         .map(String::trim)
                         .collect(Collectors.toList()),


### PR DESCRIPTION
파트너 포켓몬 설정 오류 수정

## #️⃣연관된 이슈
> #70

## 📝작업 내용
> 파트너 포켓몬 설정 오류 수정

## 🔎코드 설명
> 유저 포켓몬 id와 비교하던 코드를 전체 포켓몬 id와 비교하는 것으로 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.